### PR TITLE
Added onOtpCompleted callback to know when the otp has been fully completed

### DIFF
--- a/otpcompose/src/main/java/com/prabhatpandey/otpcompose/OtpTextField.kt
+++ b/otpcompose/src/main/java/com/prabhatpandey/otpcompose/OtpTextField.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.unit.sp
  * @param digitContainerStyle The style configuration for the digit containers.
  * @param textStyle The style configuration for the text within the digit containers.
  * @param isError Whether the OTP field is in an error state.
+ * @param onOtpCompleted Called when the OTP field is completed.
  */
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -73,6 +74,7 @@ fun OTPTextField(
         fontSize = 28.sp
     ),
     isError: Boolean = false,
+    onOtpCompleted: (Boolean) -> Unit = {}
 ) {
     val focusManager = LocalFocusManager.current
 
@@ -106,6 +108,11 @@ fun OTPTextField(
             }
             if (it.length >= numDigits) {
                 focusManager.clearFocus()
+            }
+            if (it.length == numDigits) {
+                onOtpCompleted.invoke(true)
+            } else {
+                onOtpCompleted.invoke(false)
             }
         },
         keyboardOptions = KeyboardOptions(


### PR DESCRIPTION
Added this callback so there is a way to know when you completed the OTP. This can help when you want to validate the code after fully completed without any user input.

[otp.webm](https://github.com/prabhatsdp/otp-compose/assets/24615408/ec8b86d9-4d94-4e4c-882f-bf777c8bbc6f)

